### PR TITLE
Added handlers for longer messages

### DIFF
--- a/Example/ErrorMessageViewExample/ErrorMessageViewExample/Base.lproj/Main.storyboard
+++ b/Example/ErrorMessageViewExample/ErrorMessageViewExample/Base.lproj/Main.storyboard
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="15A284" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -18,6 +19,7 @@
                         <subviews>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Login" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="8jg-y6-4P0">
                                 <rect key="frame" x="16" y="30" width="288" height="30"/>
+                                <animations/>
                                 <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="15"/>
                                 <textInputTraits key="textInputTraits"/>
                                 <connections>
@@ -26,6 +28,7 @@
                             </textField>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2cc-LJ-1bX">
                                 <rect key="frame" x="16" y="74" width="288" height="30"/>
+                                <animations/>
                                 <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="15"/>
                                 <textInputTraits key="textInputTraits"/>
                                 <connections>
@@ -33,7 +36,8 @@
                                 </connections>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sz6-Hb-kjM">
-                                <rect key="frame" x="137" y="129" width="46" height="30"/>
+                                <rect key="frame" x="137" y="169" width="46" height="30"/>
+                                <animations/>
                                 <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="15"/>
                                 <state key="normal" title="Enter">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -42,12 +46,23 @@
                                     <action selector="enterButtonAction" destination="vXZ-lx-hvc" eventType="touchUpInside" id="LBD-Od-Pwe"/>
                                 </connections>
                             </button>
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Long Message" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2kN-sn-j47">
+                                <rect key="frame" x="16" y="119" width="288" height="30"/>
+                                <animations/>
+                                <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="15"/>
+                                <textInputTraits key="textInputTraits"/>
+                                <connections>
+                                    <outlet property="delegate" destination="vXZ-lx-hvc" id="bkR-Bj-Iu5"/>
+                                </connections>
+                            </textField>
                         </subviews>
+                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
                     <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
                     <connections>
                         <outlet property="loginTextField" destination="8jg-y6-4P0" id="CE9-VR-0WL"/>
+                        <outlet property="longMessageTextField" destination="2kN-sn-j47" id="fag-fH-Hs2"/>
                         <outlet property="passTextField" destination="2cc-LJ-1bX" id="g8f-gO-QRI"/>
                     </connections>
                 </viewController>

--- a/Example/ErrorMessageViewExample/ErrorMessageViewExample/ViewController.m
+++ b/Example/ErrorMessageViewExample/ErrorMessageViewExample/ViewController.m
@@ -15,6 +15,7 @@
 
 @property (nonatomic, weak) IBOutlet UITextField *loginTextField;
 @property (nonatomic, weak) IBOutlet UITextField *passTextField;
+@property (nonatomic, weak) IBOutlet UITextField *longMessageTextField;
 
 - (IBAction)enterButtonAction;
 
@@ -28,6 +29,7 @@
     
     [self setupLoginTextField];
     [self setupPassTextField];
+    [self setupLongTextField];
 }
 
 #pragma mark - Setup methods
@@ -36,6 +38,13 @@
     [self defaultSetupTextField:self.loginTextField];
     
     [self.loginTextField bs_setupErrorMessageViewWithMessage:@"Minimum 6 characters"];
+}
+
+- (void)setupLongTextField
+{
+    [self defaultSetupTextField:self.longMessageTextField];
+    
+    [self.longMessageTextField bs_setupErrorMessageViewWithMessage:@"The error message was too long to show in the text box hence it will come up as an alert avoiding clipping of messages!, you can customize the alert button text as well!"];
 }
 
 - (void)setupPassTextField
@@ -61,6 +70,8 @@
     {
         [self.passTextField bs_showError];
     }
+    
+    [self.longMessageTextField bs_showError];
 }
 
 #pragma mark - Helpers

--- a/Example/ErrorMessageViewExample/Pods/BSErrorMessageView/Source/BSErrorMessageView.h
+++ b/Example/ErrorMessageViewExample/Pods/BSErrorMessageView/Source/BSErrorMessageView.h
@@ -27,6 +27,8 @@
 
 @property (nonatomic, copy) NSString *message;
 
+@property (nonatomic, copy) NSString *confirmationButtonText;
+
 /**
  *  Error message container and error icon background color
  *  If messageContainerTint and iconTint colors is not equal, then mainTintColor nil

--- a/Example/ErrorMessageViewExample/Pods/BSErrorMessageView/Source/BSErrorMessageView.m
+++ b/Example/ErrorMessageViewExample/Pods/BSErrorMessageView/Source/BSErrorMessageView.m
@@ -379,6 +379,12 @@ static CGFloat const kBSMessageLabelTrailingConstant = -13.5f;
 #pragma mark - Handlers
 - (void)errorIconButtonAction
 {
+    CGSize size = [self.messageLabel.text sizeWithAttributes:@{NSFontAttributeName:self.messageLabel.font}];
+    if ((size.width > self.messageLabel.bounds.size.width)) {
+        [[[UIAlertView alloc] initWithTitle:@"" message:self.messageLabel.text delegate:nil cancelButtonTitle:self.confirmationButtonText?:@"OK" otherButtonTitles: nil] show];
+        return;
+    }
+    
     self.errorIconButton.userInteractionEnabled = NO;
     
     if ( self.errorBGImageViewWidthConstraint.priority == BSLayoutPriorityAlmostRequired )


### PR DESCRIPTION
Messages that are larger than the textfield used to get trimmed and also make the UI hard to use and dismiss at times. This fix ensures longer messages are shown as alert views when error view is tapped upon.
